### PR TITLE
Fix references to links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ for these steps.
 
 ### Docs
 The user guide and API reference for this package can be found here: 
-https://shauryapednekar.github.io/text-ingestion-pipeline/
+[https://shauryapednekar.github.io/text-ingestion-pipeline/](https://shauryapednekar.github.io/text-ingestion-pipeline/)
 
 ### Demo
-A sample Google Colab notebook can be found here: https://colab.research.google.com/drive/1eQ1TxI0OBjLvQU0n79x1_bRrULRj6if6?usp=sharing
+A sample Google Colab notebook can be found here: [Google Colab Notebook - Demo](https://colab.research.google.com/drive/1eQ1TxI0OBjLvQU0n79x1_bRrULRj6if6?usp=sharing)
 
 ### Priorities
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ chunking functions, since application performance relies heavily on those two
 steps. See the usage guide for more information on how to write custom classes
 for these steps.
 
-Here is the link to the GitHub repo: https://github.com/shauryapednekar/text-ingestion-pipeline
+Here is the link to the GitHub repo: [https://github.com/shauryapednekar/text-ingestion-pipeline](https://github.com/shauryapednekar/text-ingestion-pipeline)
 
 ### Priorities
 

--- a/docs/user-guide/demo.md
+++ b/docs/user-guide/demo.md
@@ -1,2 +1,2 @@
 ### Demo
-A sample Google Colab notebook can be found here: https://colab.research.google.com/drive/1eQ1TxI0OBjLvQU0n79x1_bRrULRj6if6?usp=sharing
+A sample Google Colab notebook can be found here: [Google Colab Notebook - Demo](https://colab.research.google.com/drive/1eQ1TxI0OBjLvQU0n79x1_bRrULRj6if6?usp=sharing)


### PR DESCRIPTION
Fix the formatting for links in the markdown files, since it wasn't otherwise working well with
mkdocs.