### PR TITLE
Link to README for mermaid diagram

### DIFF
--- a/docs/user-guide/design.md
+++ b/docs/user-guide/design.md
@@ -1,6 +1,11 @@
 ### Design Overview
 
 #### Class Structure
+
+NOTE: Mermaid diagrams aren't rendering on GitHub Pages for some reason. See
+[the README](https://github.com/shauryapednekar/text-ingestion-pipeline?tab=readme-ov-file#class-structure) 
+for the diagram: 
+
 Here's the high level overview of the classes and how they interact with each other.
 
 ```mermaid


### PR DESCRIPTION
Either MKDocs or GitHub Pages isn't rendering mermaid diagrams correctly. Will need to look into the configuration later to fix this. For now, link to the README since that renders the diagram correctly.